### PR TITLE
[cost_saturation] Fix memory leak with Cartesian abstractions by using in-stack object instead of unique_ptr

### DIFF
--- a/src/search/cost_saturation/cartesian_abstraction_generator.cc
+++ b/src/search/cost_saturation/cartesian_abstraction_generator.cc
@@ -90,7 +90,7 @@ void CartesianAbstractionGenerator::build_abstractions_for_subtasks(
         << timer.get_remaining_time() << endl;
     int remaining_subtasks = subtasks.size();
     for (const shared_ptr<AbstractTask> &subtask : subtasks) {
-        auto cegar = make_unique<cartesian_abstractions::CEGAR>(
+        cartesian_abstractions::CEGAR cegar(
             subtask,
             cartesian_abstractions::get_subtask_limit(
                 max_states, num_states, remaining_subtasks),
@@ -101,10 +101,9 @@ void CartesianAbstractionGenerator::build_abstractions_for_subtasks(
             max_concrete_states_per_abstract_state, max_state_expansions,
             transition_representation, *rng, log, dot_graph_verbosity);
         cout << endl;
-        auto cartesian_abstraction = cegar->extract_abstraction();
+        auto cartesian_abstraction = cegar.extract_abstraction();
         // If the timer expired, the goal distances might only be lower bounds.
-        vector<int> goal_distances = cegar->get_goal_distances();
-        cegar.release(); // Release memory for shortest paths, flaw search, etc.
+        vector<int> goal_distances = cegar.get_goal_distances();
 
         /* If we run out of memory while building an abstraction, we discard it
            to avoid running out of memory during the abstraction conversion. */


### PR DESCRIPTION
Unique pointer with `.release()` call after each Cartesian abstraction was not releasing memory, while a in-stack object does it.