### PR TITLE
Fix cost saturation version of pho excluding abstractions that contain dead end information

### DIFF
--- a/src/search/cost_saturation/pho_heuristic.cc
+++ b/src/search/cost_saturation/pho_heuristic.cc
@@ -32,11 +32,13 @@ PhO::PhO(
     vector<vector<int>> saturated_costs_by_abstraction;
     saturated_costs_by_abstraction.reserve(num_abstractions);
     h_values_by_abstraction.reserve(num_abstractions);
+    abstraction_has_dead_ends = vector<bool>(abstractions.size(), false);
     for (int i = 0; i < num_abstractions; ++i) {
         const Abstraction &abstraction = *abstractions[i];
         vector<int> h_values = abstraction.compute_goal_distances(costs);
         vector<int> saturated_costs =
             abstraction.compute_saturated_costs(h_values);
+        abstraction_has_dead_ends[i] = any_of(execution::unseq, h_values.begin(), h_values.end(), [](int x) {return x == cost_saturation::INF;});
         h_values_by_abstraction.push_back(move(h_values));
         saturated_costs_by_abstraction.push_back(move(saturated_costs));
     }
@@ -112,7 +114,7 @@ CostPartitioningHeuristic PhO::compute_cost_partitioning(
     CostPartitioningHeuristic cp_heuristic;
     for (int i = 0; i < num_abstractions; ++i) {
         double weight = solution[i];
-        if (weight == 0.0) {
+        if (weight == 0.0 && !abstraction_has_dead_ends[i]) {
             // This abstraction is assigned a weight of zero, so we can skip it.
             continue;
         }

--- a/src/search/cost_saturation/pho_heuristic.cc
+++ b/src/search/cost_saturation/pho_heuristic.cc
@@ -24,7 +24,9 @@ namespace cost_saturation {
 PhO::PhO(
     const Abstractions &abstractions, const vector<int> &costs,
     lp::LPSolverType solver_type, bool saturated, const utils::LogProxy &log)
-    : lp_solver(solver_type), log(log) {
+    : lp_solver(solver_type),
+      abstraction_has_unsolvable_states(abstractions.size(), false),
+      log(log) {
     double infinity = lp_solver.get_infinity();
     int num_abstractions = abstractions.size();
     int num_operators = costs.size();
@@ -32,13 +34,14 @@ PhO::PhO(
     vector<vector<int>> saturated_costs_by_abstraction;
     saturated_costs_by_abstraction.reserve(num_abstractions);
     h_values_by_abstraction.reserve(num_abstractions);
-    abstraction_has_dead_ends = vector<bool>(abstractions.size(), false);
     for (int i = 0; i < num_abstractions; ++i) {
         const Abstraction &abstraction = *abstractions[i];
         vector<int> h_values = abstraction.compute_goal_distances(costs);
+        abstraction_has_unsolvable_states[i] = any_of(
+            execution::unseq, h_values.begin(), h_values.end(),
+            [](int x) { return x == cost_saturation::INF; });
         vector<int> saturated_costs =
             abstraction.compute_saturated_costs(h_values);
-        abstraction_has_dead_ends[i] = any_of(execution::unseq, h_values.begin(), h_values.end(), [](int x) {return x == cost_saturation::INF;});
         h_values_by_abstraction.push_back(move(h_values));
         saturated_costs_by_abstraction.push_back(move(saturated_costs));
     }
@@ -114,8 +117,9 @@ CostPartitioningHeuristic PhO::compute_cost_partitioning(
     CostPartitioningHeuristic cp_heuristic;
     for (int i = 0; i < num_abstractions; ++i) {
         double weight = solution[i];
-        if (weight == 0.0 && !abstraction_has_dead_ends[i]) {
-            // This abstraction is assigned a weight of zero, so we can skip it.
+        if (weight == 0.0 && !abstraction_has_unsolvable_states[i]) {
+            // This abstraction is assigned a weight of zero and has no
+            // unsolvable states, so we can skip it.
             continue;
         }
         vector<int> weighted_h_values;

--- a/src/search/cost_saturation/pho_heuristic.h
+++ b/src/search/cost_saturation/pho_heuristic.h
@@ -12,6 +12,7 @@ namespace cost_saturation {
 class PhO {
     lp::LPSolver lp_solver;
     std::vector<std::vector<int>> h_values_by_abstraction;
+    std::vector<bool> abstraction_has_dead_ends;
     utils::LogProxy log;
 
 public:

--- a/src/search/cost_saturation/pho_heuristic.h
+++ b/src/search/cost_saturation/pho_heuristic.h
@@ -12,7 +12,7 @@ namespace cost_saturation {
 class PhO {
     lp::LPSolver lp_solver;
     std::vector<std::vector<int>> h_values_by_abstraction;
-    std::vector<bool> abstraction_has_dead_ends;
+    std::vector<bool> abstraction_has_unsolvable_states;
     utils::LogProxy log;
 
 public:


### PR DESCRIPTION
The abstraction skip on abstractions with zero weights at line 115 in cost_saturation/pho_heuristic.cc can throw away dead end information, since these abstractions can still contain states with infinite abstract goal distances.
This fix makes sure that only abstractions that contain no infinite abstract goal distances are thrown away.