### PR TITLE
[erase_if] Use C++ 20 erase_if instead of remove_if + erase

### DIFF
--- a/src/search/cartesian_abstractions/shortest_paths.cc
+++ b/src/search/cartesian_abstractions/shortest_paths.cc
@@ -351,21 +351,17 @@ void ShortestPaths::update_incrementally(
         if (use_cache) {
             // Remove invalid transitions from children and parents vectors.
             int num_parents_before = parents[state].size();
-            parents[state].erase(
-                remove_if(
-                    parents[state].begin(), parents[state].end(),
-                    [&](const Transition &parent) {
-                        assert(abstraction.has_transition(
-                            state, parent.op_id, parent.target_id));
-                        bool valid_parent = !states[parent.target_id].dirty;
-                        if (!valid_parent) {
-                            remove_child(
-                                parent.target_id,
-                                Transition(parent.op_id, state));
-                        }
-                        return !valid_parent;
-                    }),
-                parents[state].end());
+            erase_if(parents[state], [&](const Transition &parent) {
+                assert(abstraction.has_transition(
+                    state, parent.op_id, parent.target_id));
+                bool valid_parent = !states[parent.target_id].dirty;
+                if (!valid_parent) {
+                    remove_child(
+                        parent.target_id,
+                        Transition(parent.op_id, state));
+                }
+                return !valid_parent;
+            });
             int num_parents_after = parents[state].size();
             num_parents += num_parents_after - num_parents_before;
             reconnected = !parents[state].empty();

--- a/src/search/cartesian_abstractions/shortest_paths.cc
+++ b/src/search/cartesian_abstractions/shortest_paths.cc
@@ -357,8 +357,7 @@ void ShortestPaths::update_incrementally(
                 bool valid_parent = !states[parent.target_id].dirty;
                 if (!valid_parent) {
                     remove_child(
-                        parent.target_id,
-                        Transition(parent.op_id, state));
+                        parent.target_id, Transition(parent.op_id, state));
                 }
                 return !valid_parent;
             });

--- a/src/search/cartesian_abstractions/subtask_generators.cc
+++ b/src/search/cartesian_abstractions/subtask_generators.cc
@@ -34,9 +34,11 @@ class SortFactsByIncreasingHaddValues {
 public:
     explicit SortFactsByIncreasingHaddValues(
         const shared_ptr<AbstractTask> &task)
-        : hadd(make_unique<additive_heuristic::AdditiveHeuristic>(
-              tasks::AxiomHandlingType::APPROXIMATE_NEGATIVE, task, false,
-              "h^add within CEGAR abstractions", utils::Verbosity::SILENT)) {
+        : hadd(
+              make_unique<additive_heuristic::AdditiveHeuristic>(
+                  tasks::AxiomHandlingType::APPROXIMATE_NEGATIVE, task, false,
+                  "h^add within CEGAR abstractions",
+                  utils::Verbosity::SILENT)) {
         TaskProxy task_proxy(*task);
         hadd->compute_heuristic_for_cegar(task_proxy.get_initial_state());
     }
@@ -50,7 +52,7 @@ static void remove_initial_state_facts(
     const TaskProxy &task_proxy, Facts &facts) {
     State initial_state = task_proxy.get_initial_state();
     erase_if(facts, [&](FactPair fact) {
-                return initial_state[fact.var].get_value() == fact.value;
+        return initial_state[fact.var].get_value() == fact.value;
     });
 }
 

--- a/src/search/cartesian_abstractions/subtask_generators.cc
+++ b/src/search/cartesian_abstractions/subtask_generators.cc
@@ -49,13 +49,9 @@ public:
 static void remove_initial_state_facts(
     const TaskProxy &task_proxy, Facts &facts) {
     State initial_state = task_proxy.get_initial_state();
-    facts.erase(
-        remove_if(
-            facts.begin(), facts.end(),
-            [&](FactPair fact) {
+    erase_if(facts, [&](FactPair fact) {
                 return initial_state[fact.var].get_value() == fact.value;
-            }),
-        facts.end());
+    });
 }
 
 static void order_facts(

--- a/src/search/cartesian_abstractions/transition_rewirer.cc
+++ b/src/search/cartesian_abstractions/transition_rewirer.cc
@@ -68,11 +68,9 @@ static int lookup_value(const vector<FactPair> &facts, int var) {
 
 static void remove_transitions_with_given_target(
     Transitions &transitions, int state_id) {
-    auto new_end = remove_if(
-        transitions.begin(), transitions.end(),
-        [state_id](const Transition &t) { return t.target_id == state_id; });
-    assert(new_end != transitions.end());
-    transitions.erase(new_end, transitions.end());
+    erase_if(transitions, [state_id](const Transition &t) {
+        return t.target_id == state_id;
+    });
 }
 
 static void add_transition(

--- a/src/search/cost_saturation/unsolvability_heuristic.cc
+++ b/src/search/cost_saturation/unsolvability_heuristic.cc
@@ -44,15 +44,11 @@ UnsolvabilityHeuristic::UnsolvabilityHeuristic(
     // Remove lookup tables that only contain entries equal to 0 or infinity.
     for (auto &cp : cp_heuristics) {
         auto &tables = cp.lookup_tables;
-        tables.erase(
-            remove_if(
-                tables.begin(), tables.end(),
-                [](const CostPartitioningHeuristic::LookupTable &table) {
-                    return all_of(
-                        table.h_values.begin(), table.h_values.end(),
-                        [](int h) { return h == 0 || h == INF; });
-                }),
-            tables.end());
+        erase_if(tables, [](const CostPartitioningHeuristic::LookupTable &table) {
+            return all_of(
+                table.h_values.begin(), table.h_values.end(),
+                [](int h) { return h == 0 || h == INF; });
+        });
         tables.shrink_to_fit();
     }
 }


### PR DESCRIPTION
C++ 20 introduced `erase_if` function, combining `remove_if` and `erase` in a single step.

This change makes the code more readable and marginally faster.